### PR TITLE
Add drive context menu and normalize paths

### DIFF
--- a/src/App/Utils/CommandLineParser.cs
+++ b/src/App/Utils/CommandLineParser.cs
@@ -23,7 +23,7 @@ internal static class CommandLineParser
             throw new Exception($"'{args[1]}' doesn't exist");
         }
 
-        return args[1];
+        return args[1].Replace("\\", "/");
     }
 
     private static bool Exists(string path)

--- a/src/Installer/Product.wxs
+++ b/src/Installer/Product.wxs
@@ -41,6 +41,14 @@
             <RegistryValue Type="string" Value="&quot;[INSTALLFOLDER]ShowWhatProcessLocksFile.exe&quot; &quot;%1&quot;"/>
           </RegistryKey>
         </RegistryKey>
+
+        <RegistryKey Root="HKCU" Key="Software\Classes\Drive\shell\ShowWhatProcessLocksFile">
+          <RegistryValue Type="string" Value="Show what locks this drive"/>
+          <RegistryValue Type="string" Name="Icon" Value="&quot;[INSTALLFOLDER]icon.ico&quot;"/>
+          <RegistryKey Key="command">
+            <RegistryValue Type="string" Value="&quot;[INSTALLFOLDER]ShowWhatProcessLocksFile.exe&quot; %1"/>
+          </RegistryKey>
+        </RegistryKey>
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
This pull request adds a context menu entry for drives, allowing users to right‑click a drive and quickly check which processes are locking it (helpful for resolving the "This device is currently in use" error when ejecting removable drives).

It also updates `CommandLineParser` to normalize paths by converting backslashes to forward slashes, preventing trailing backslashes from unintentionally escaping quotes and causing errors such as `'D:"' doesn't exist`.